### PR TITLE
Fix three code bugs

### DIFF
--- a/services/api/src/config/auth.config.ts
+++ b/services/api/src/config/auth.config.ts
@@ -1,7 +1,14 @@
 import { registerAs } from '@nestjs/config';
 
 export default registerAs('auth', () => ({
-  jwtSecret: process.env.JWT_SECRET || 'haroonnet-jwt-secret-key',
+  // Do not fall back to a weak hardcoded default; require explicit secret in production
+  jwtSecret:
+    process.env.JWT_SECRET ||
+    (process.env.NODE_ENV === 'production'
+      ? (() => {
+          throw new Error('JWT_SECRET must be set in production');
+        })()
+      : 'dev-insecure-secret'),
   jwtExpiresIn: process.env.JWT_EXPIRES_IN || '24h',
   refreshTokenExpiresIn: process.env.REFRESH_TOKEN_EXPIRES_IN || '7d',
   bcryptRounds: parseInt(process.env.BCRYPT_ROUNDS, 10) || 12,

--- a/services/api/src/modules/users/entities/user.entity.ts
+++ b/services/api/src/modules/users/entities/user.entity.ts
@@ -73,9 +73,18 @@ export class User {
   @BeforeInsert()
   @BeforeUpdate()
   async hashPassword() {
-    if (this.password) {
-      this.password = await bcrypt.hash(this.password, 12);
+    if (!this.password) {
+      return;
     }
+
+    // Avoid double-hashing if the password already looks like a bcrypt hash
+    const bcryptPattern = /^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$/;
+    const isAlreadyHashed = bcryptPattern.test(this.password);
+    if (isAlreadyHashed) {
+      return;
+    }
+
+    this.password = await bcrypt.hash(this.password, 12);
   }
 
   async validatePassword(password: string): Promise<boolean> {

--- a/services/worker/app/tasks/billing.py
+++ b/services/worker/app/tasks/billing.py
@@ -27,7 +27,7 @@ class DatabaseTask(Task):
             db.close()
 
     def run_with_db(self, db: Session, *args, **kwargs):
-        return self.run(*args, **kwargs)
+        return self.run(db, *args, **kwargs)
 
 
 @celery.task(bind=True, base=DatabaseTask)


### PR DESCRIPTION
Fixes three bugs: Celery `DatabaseTask` not passing DB session, user password double-hashing, and an insecure hardcoded JWT default secret.

The Celery `DatabaseTask` fix ensures bound tasks reliably receive an open `Session`, preventing runtime errors. The password hashing fix prevents login failures by avoiding double-hashing already hashed passwords. The JWT secret fix enhances security by requiring an explicit secret in production and providing a safer development fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-76afdfef-543a-412e-a269-913c079fcca1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76afdfef-543a-412e-a269-913c079fcca1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

